### PR TITLE
Move dconf_settings from vars to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
-# defaults file for dconf-settings
+# defaults file for dconf-settings# defaults file for dconf-settings
+
+dconf_settings: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-# defaults file for dconf-settings# defaults file for dconf-settings
+# defaults file for dconf-settings
 
 dconf_settings: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,2 @@
 ---
 # vars file for dconf-settings
-
-dconf_settings: []


### PR DESCRIPTION
Ansible does not accept variable specified the way it is shown in the example in Readme. This PR fixes this issue.